### PR TITLE
feat: Encode tokens when proxying downloads

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,6 +7,8 @@ tasks:
     desc: Run the server
     cmds:
       - go run ./cmd/server
+    env:
+      MODULES_PROXY_SECRET: c3VwZXJzZWNyZXQxMjM0IQ==
 
   run:tls:
     desc: Run the server with TLS
@@ -15,6 +17,7 @@ tasks:
     cmds:
       - go run ./cmd/server
     env:
+      MODULES_PROXY_SECRET: c3VwZXJzZWNyZXQxMjM0IQ==
       PORT: 8443
       TLS_ENABLED: true
       TLS_KEY_FILE: deploy/localhost.key

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the GNU Affero
 // GPL license that can be found in the LICENSE file.
 
-package github
+package auth
 
 import (
 	"context"
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-func AddTokenMiddleware(next http.Handler) http.Handler {
+func TokenMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		header := r.Header.Get("Authorization")
 		if len(header) >= 7 && strings.ToLower(header[0:7]) == "bearer " {

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -14,6 +14,8 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+
+	"github.com/hedlund/orbit/pkg/auth"
 )
 
 const (
@@ -126,7 +128,7 @@ func (s *Service) makeRequest(ctx context.Context, uri string) (io.ReadCloser, e
 	req.Header.Add("Accept", contentType)
 	req.Header.Add("X-GitHub-Api-Version", apiVersion)
 
-	if token := GetToken(ctx, s.cfg.Token); token != "" {
+	if token := auth.GetToken(ctx, s.cfg.Token); token != "" {
 		req.Header.Add("Authorization", "Bearer "+token)
 	}
 


### PR DESCRIPTION
When the proxy download endpoint is called,
Terraform will not include any access token.
In cases when Orbit is running without a default
access token, that means all requests will result
in a 404 from Github.

This changes the behaviour so that whenever a token is explicitly passed to the Downloads endpoint (i.e. the one giving Terraform the URL to actually
download - the proxy endpoint), it encodes the token using AES and adds it as a query parameter to the
URL returned.

That way the proxy endpoint can decrypt the token
from the URL and use it when calling Github. The
validity fo the encrypted token is 60 seconds by
default.

Right now the AES secret is passed as a byte slice in the environment variables (i.e. it must be
base64 encoded), and it is expected to be either
16, 24, or 32 bytes long.