### PR TITLE
fix: Chart ENV values

### DIFF
--- a/deploy/charts/orbit/templates/deployment.yaml
+++ b/deploy/charts/orbit/templates/deployment.yaml
@@ -59,15 +59,18 @@ spec:
               value: {{ .Values.cache.path }}
             - name: CACHE_EXPIRY
               value: {{ .Values.cache.expiry }}
+          {{- with .Values.extraEnvs }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
             {{- end }}
           {{- if .Values.github.token}}
           envFrom: 
             - secretRef:
               name: {{ include "orbit.fullname "}}
-          {{- else if .Values.existing_token }}
+          {{- else if .Values.github.token_secret }}
           envFrom: 
-          name: {{ .Values.token_secret }}
             - secretRef:
+                name: {{ .Values.github.token_secret }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/charts/orbit/templates/deployment.yaml
+++ b/deploy/charts/orbit/templates/deployment.yaml
@@ -71,7 +71,38 @@ spec:
           envFrom: 
             - secretRef:
                 name: {{ .Values.github.token_secret }}
+            {{- if .Values.extraSecretsMounts.enabled }}
+          volumeMounts:
+            {{- range .Values.extraSecretsMounts.secrets }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              readOnly: {{ .readOnly }}
+            {{- end }}
+            {{- end }}
           {{- end }}
+        {{- if .Values.extraSecretsMounts.enabled }}
+      volumes:
+        {{- range .Values.extraSecretsMounts.secrets }}
+        {{- if .secretName }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+            defaultMode: {{ .defaultMode }}
+            {{- with .items }}
+            items:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+        {{- else if .projected }}
+        - name: {{ .name }}
+          projected:
+            {{- toYaml .projected | nindent 12 }}
+        {{- else if .csi }}
+        - name: {{ .name }}
+          csi:
+            {{- toYaml .csi | nindent 12 }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/charts/orbit/values.yaml
+++ b/deploy/charts/orbit/values.yaml
@@ -39,6 +39,9 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+extraSecretsMounts:
+  enabled: false
+  secrets: []
 
 podAnnotations: {}
 

--- a/deploy/charts/orbit/values.yaml
+++ b/deploy/charts/orbit/values.yaml
@@ -9,10 +9,11 @@ cache:
 github:
   # Existing secret to read token from
   token_secret: ""
+
   # Or create a new secret with this token.
   token: ""
-  # Limit proxy to a set of repositories. Defaults to allow all
 
+  # Limit proxy to a set of repositories. Defaults to allow all
   repositories: ""
 replicaCount: 1
 
@@ -26,6 +27,9 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+
+# Support for custom env variables
+extraEnvs: []
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Fix setting secrets from an existing secret.
Allow passing extra env vars to the chart.
