### PR TITLE
chore: Bump to Go 1.22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.22"
 
       - name: Run tests
         run: go test -race -cover ./...

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.20-alpine AS build
+FROM docker.io/library/golang:1.22-alpine AS build
 ARG entrypoint="./cmd/server"
 
 WORKDIR /app

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,11 +5,10 @@
 package main
 
 import (
+	"log/slog"
 	"net/http"
 	"os"
 	"time"
-
-	"golang.org/x/exp/slog"
 
 	"github.com/hedlund/orbit/pkg/auth"
 	"github.com/hedlund/orbit/pkg/envconfig"
@@ -35,7 +34,7 @@ func main() {
 	var cfg config
 	envconfig.MustProcess(&cfg)
 
-	log := slog.New(slog.NewTextHandler(os.Stdout))
+	log := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	var repo modules.Repository
 	repo = github.New(cfg.Github, &http.Client{

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/hedlund/orbit
 
-go 1.19
-
-require golang.org/x/exp v0.0.0-20230310171629-522b1b587ee0
+go 1.22

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,0 @@
-golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=
-golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
-golang.org/x/exp v0.0.0-20230310171629-522b1b587ee0 h1:LGJsf5LRplCck6jUCH3dBL2dmycNruWNF5xugkSlfXw=
-golang.org/x/exp v0.0.0-20230310171629-522b1b587ee0/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=


### PR DESCRIPTION
And since we use Go 1.22, we can remove the dependency on `exp/slog`.